### PR TITLE
Remove fixed class from top menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<div class="ui teal inverted fixed menu">
+<div class="ui teal inverted menu">
     {% if include.page == 'home' %}
         <a href="/" class="active item">
     {% else %}


### PR DESCRIPTION
Hello!

This pull request ensures that the top menu of the Two Factor Auth website does not stay fixed when the page is scrolled downwards and affects pull request #2.

Thanks,
psgs :palm_tree: 
